### PR TITLE
References page: standardize navigation, language, add more links

### DIFF
--- a/src/pages/_data/navigation/footerLinks.json5
+++ b/src/pages/_data/navigation/footerLinks.json5
@@ -13,6 +13,7 @@
       title: "Resources",
       links: [
         { title: "HDK", url: "https://docs.rs/hdk", external: true },
+        { title: "HDI", url: "https://docs.rs/hdi", external: true },
         { title: "App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
         { title: "Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
         { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},

--- a/src/pages/_data/navigation/footerLinks.json5
+++ b/src/pages/_data/navigation/footerLinks.json5
@@ -12,10 +12,12 @@
     {
       title: "Resources",
       links: [
-        { title: "HDK (Rust)", url: "https://docs.rs/hdk", external: true },
-        { title: "App API reference", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
-        { title: "Admin API reference", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
-        { title: "CLI", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
+        { title: "HDK", url: "https://docs.rs/hdk", external: true },
+        { title: "App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
+        { title: "Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
+        { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},
+        { title: "Client (Rust)", url: "https://github.com/holochain/holochain-client-rust", external: true},
+        { title: "hc", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
         { title: "Glossary", url: "/references/glossary/", external: true },
       ]
     },

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -27,10 +27,10 @@
       ]
     },
     { title: "References", url: "/references/", children: [
-        { title: "HDK (Rust)", url: "https://docs.rs/hdk", external: true },
+        { title: "HDK reference", url: "https://docs.rs/hdk", external: true },
         { title: "App API reference", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
         { title: "Admin API reference", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
-        { title: "CLI", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
+        { title: "hc CLI reference", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
         { title: "Glossary", url: "/references/glossary/" },
       ]
     },

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -28,6 +28,7 @@
     },
     { title: "References", url: "/references/", children: [
         { title: "HDK", url: "https://docs.rs/hdk", external: true },
+        { title: "HDI", url: "https://docs.rs/hdi", external: true },
         { title: "App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
         { title: "Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
         { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -28,11 +28,10 @@
     },
     { title: "References", url: "/references/", children: [
         { title: "HDK", url: "https://docs.rs/hdk", external: true },
-        { title: "HDI", url: "https://docs.rs/hdi", external: true },
-        { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},
-        { title: "Client (Rust)", url: "https://github.com/holochain/holochain-client-rust", external: true},
         { title: "App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
         { title: "Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
+        { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},
+        { title: "Client (Rust)", url: "https://github.com/holochain/holochain-client-rust", external: true},
         { title: "hc", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
         { title: "Glossary", url: "/references/glossary/" },
       ]

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -27,10 +27,13 @@
       ]
     },
     { title: "References", url: "/references/", children: [
-        { title: "HDK reference", url: "https://docs.rs/hdk", external: true },
-        { title: "App API reference", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
-        { title: "Admin API reference", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
-        { title: "hc CLI reference", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
+        { title: "HDK", url: "https://docs.rs/hdk", external: true },
+        { title: "HDI", url: "https://docs.rs/hdi", external: true },
+        { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},
+        { title: "Client (Rust)", url: "https://github.com/holochain/holochain-client-rust", external: true},
+        { title: "hc", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
+        { title: "Conductor App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
+        { title: "Conductor Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
         { title: "Glossary", url: "/references/glossary/" },
       ]
     },

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -31,9 +31,9 @@
         { title: "HDI", url: "https://docs.rs/hdi", external: true },
         { title: "Client (Javascript)", url: "https://github.com/holochain/holochain-client-js", external: true},
         { title: "Client (Rust)", url: "https://github.com/holochain/holochain-client-rust", external: true},
+        { title: "App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
+        { title: "Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
         { title: "hc", url: "https://github.com/holochain/holochain/tree/main/crates/hc", external: true },
-        { title: "Conductor App API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html", external: true },
-        { title: "Conductor Admin API", url: "https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html", external: true },
         { title: "Glossary", url: "/references/glossary/" },
       ]
     },

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -1,8 +1,8 @@
 ---
 title: Holochain Programming References
 tocData:
-  - text: Rust HDK
-    href: rust-hdk
+  - text: HDK
+    href: hdk-and-hdi
   - text: Conductor APIs
     href: conductor-apis
   - text: Conductor Client
@@ -15,11 +15,12 @@ tocData:
     href: example-applications-and-tutorials
 ---
 
-## Rust HDK
+## HDK and HDI
 
-When you write a Holochain application, the part that lives in Holochain is called a [DNA](../concepts/2_application_architecture/#layers-of-the-application-stack). It runs in a WebAssembly sandbox and talks to the host, or conductor, through the host API. The Rust HDK (Holochain Development Kit) makes it easy for you to write your DNAs in the Rust programming language.
+When you write a Holochain application, the part that lives in Holochain is called a [DNA](../concepts/2_application_architecture/#layers-of-the-application-stack). It runs in a WebAssembly sandbox and talks to the host, or conductor, through the host API. The HDK makes it easy for you to write your DNA coordinator zomes. While the HDI lets you write your DNA integrity zomes.
 
-* **[HDK reference](https://docs.rs/hdk){target=_blank}**
+* **[HDK reference (Rust)](https://docs.rs/hdk){target=_blank}**
+* **[HDI reference (Rust)](https://docs.rs/hdi){target=_blank}**
 
 ## Conductor APIs
 
@@ -40,6 +41,7 @@ develop Holochain Apps with a web-based UI, **it is likely that all you'll ever 
 
 * **[Conductor Client reference (JavaScript)](https://github.com/holochain/holochain-client-js){target=_blank}**
 * **[Conductor Client reference (Rust)](https://github.com/holochain/holochain-client-rust){target=_blank}**
+* **[Conductor Client reference (.NET / C#)](https://github.com/holochain-open-dev/holonet){target=_blank}** (Community-maintained)
 
 ## Conductor configuration
 

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -1,5 +1,16 @@
 ---
 title: Holochain Programming References
+tocData:
+  - text: Rust HDK
+    href: rust-hdk
+  - text: Conductor APIs
+    href: conductor-apis
+  - text: Conductor configuration
+    href: conductor-configuration
+  - text: Binaries
+    href: binaries
+  - text: Example applications
+    href: example-applications-and-tutorials
 ---
 
 ## Rust HDK

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -19,8 +19,8 @@ tocData:
 
 When you write a Holochain application, the part that lives in Holochain is called a [DNA](../concepts/2_application_architecture/#layers-of-the-application-stack). It runs in a WebAssembly sandbox and talks to the host, or conductor, through the host API. The HDK makes it easy for you to write your DNA coordinator zomes. While the HDI lets you write your DNA integrity zomes.
 
-* **[HDK reference (Rust)](https://docs.rs/hdk){target=_blank}**
-* **[HDI reference (Rust)](https://docs.rs/hdi){target=_blank}**
+* **[HDK reference](https://docs.rs/hdk){target=_blank}**
+* **[HDI reference](https://docs.rs/hdi){target=_blank}**
 
 ## Conductor APIs
 
@@ -36,12 +36,11 @@ For both of these APIs, you make an RPC call sending a MessagePack-serialized re
 
 ## Conductor Client
 
-For ergonomic interaction with those two API's there are two client implementations: One in JavaScript and one in Rust. If you intend to
-develop Holochain Apps with a web-based UI, **it is likely that all you'll ever need is the [JavaScript client](https://www.npmjs.com/package/@holochain/client){target=_blank}**.
+For ergonomic interaction with those two API's there are two officially supported client implementations: One in JavaScript and one in Rust. If you intend to develop Holochain Apps with a web-based UI, **it is likely that all you'll ever need is the [JavaScript client](https://www.npmjs.com/package/@holochain/client){target=_blank}**.
 
 * **[Conductor Client reference (JavaScript)](https://github.com/holochain/holochain-client-js){target=_blank}**
-* **[Conductor Client reference (Rust)](https://github.com/holochain/holochain-client-rust){target=_blank}**
-* **[Conductor Client reference (.NET / C#)](https://github.com/holochain-open-dev/holonet){target=_blank}** (Community-maintained)
+* **[Conductor Client reference (Rust)](https://docs.rs/holochain_client/latest/holochain_client/){target=_blank}**
+* **[Conductor Client reference (C#)](https://github.com/holochain-open-dev/holochain-client-csharp){target=_blank}** (Community-maintained)
 
 ## Conductor configuration
 

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -34,7 +34,7 @@ For both of these APIs, you make an RPC call sending a MessagePack-serialized re
 For ergonomic interaction with those two API's there are two client implementations: One in JavaScript and one in Rust. If you intend to
 develop Holochain Apps with a web-based UI, **it is likely that all you'll ever need is the [JavaScript client](https://www.npmjs.com/package/@holochain/client){target=_blank}**.
 
-* **[Holochain client JavaScript](https://github.com/holochain/holochain-conductor-api){target=_blank}**
+* **[Holochain client JavaScript](https://github.com/holochain/holochain-client-js){target=_blank}**
 * **[Holochain client Rust](https://github.com/holochain/holochain-client-rust){target=_blank}**
 
 ## Conductor configuration

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -5,6 +5,8 @@ tocData:
     href: rust-hdk
   - text: Conductor APIs
     href: conductor-apis
+  - text: Conductor Client
+    href: conductor-apis
   - text: Conductor configuration
     href: conductor-configuration
   - text: Binaries
@@ -28,14 +30,16 @@ The conductor exposes two RPC APIs over WebSocket interfaces:
 
 For both of these APIs, you make an RPC call sending a MessagePack-serialized request to the conductor over WebSocket and listening for a response. On the interface that exposes the app API, you can also listen for [**signals**](./glossary/#signal) broadcast by cells.
 
-* **[Admin API reference](https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html){target=_blank}**
-* **[App API reference](https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html){target=_blank}**
+* **[Conductor Admin API reference](https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html){target=_blank}**
+* **[Conductor App API reference](https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AppRequest.html){target=_blank}**
+
+## Conductor Client
 
 For ergonomic interaction with those two API's there are two client implementations: One in JavaScript and one in Rust. If you intend to
 develop Holochain Apps with a web-based UI, **it is likely that all you'll ever need is the [JavaScript client](https://www.npmjs.com/package/@holochain/client){target=_blank}**.
 
-* **[Holochain client JavaScript](https://github.com/holochain/holochain-client-js){target=_blank}**
-* **[Holochain client Rust](https://github.com/holochain/holochain-client-rust){target=_blank}**
+* **[Conductor Client reference (JavaScript)](https://github.com/holochain/holochain-client-js){target=_blank}**
+* **[Conductor Client reference (Rust)](https://github.com/holochain/holochain-client-rust){target=_blank}**
 
 ## Conductor configuration
 

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -1,7 +1,7 @@
 ---
 title: Holochain Programming References
 tocData:
-  - text: HDK
+  - text: HDK and HDI
     href: hdk-and-hdi
   - text: Conductor APIs
     href: conductor-apis

--- a/src/pages/references/index.md
+++ b/src/pages/references/index.md
@@ -66,3 +66,4 @@ Studying existing Holochain applications and tutorials can provide valuable insi
 
 * [Holochain Open Dev](https://github.com/holochain-open-dev)
 * [Holochain Foundation sample apps](https://github.com/holochain-apps)
+* [Holo developer training materials](https://github.com/holochain-immersive)


### PR DESCRIPTION
Improvements to References page:
- standardize & modify names of sidebar links
- add page sections navigator
- no longer label the HDK as "HDK (Rust)" as there are currently no other HDKs available to distinguish against
- add link to HDI and explanation text
- add links to js & rust client docs to sidebar
- add link to community-maintained clients (C#)
- add link to developer immersive slides & exercises 

**todo**
- link to additional example apps? (i.e. acorn, mewsfeed, etc.)
- link to holochain dev agencies? (i.e. lightningrodlabs, darksoil, buildyourwebapp)?

@pdaoust